### PR TITLE
Logic in selecting worst sample seems flawed

### DIFF
--- a/R/clhs-data.frame.R
+++ b/R/clhs-data.frame.R
@@ -131,7 +131,8 @@ clhs.data.frame <- function(
   
   obj <- res$obj # value of the objective function
   delta_obj_continuous <- res$delta_obj_continuous
-  
+  sample.weights <- res$sample.weights
+                           
   if (cost_mode) {
     # (initial) operational cost
     op_cost <- sum(cost[i_sampled, ])
@@ -179,8 +180,10 @@ clhs.data.frame <- function(
     }
     else {
       # remove the worse sampled & resample
-      worse <- max(delta_obj_continuous[!i_sampled %in% include])
-      i_worse <- which(delta_obj_continuous[!i_sampled %in% include] == worse)
+      sample.weights <- sample.weights + 1 ## to ensure all weights are positive
+      sample.weights[i_sampled %in% include] <- 0 ## to ensure we don't select any include samples as the worst
+      worse <- max(sample.weights)
+      i_worse <- which(sample.weights == worse)
       # If there's more than one worse candidate, we pick one at random
       if (length(i_worse) > 1) i_worse <- sample(i_worse, size = 1)
       
@@ -206,6 +209,7 @@ clhs.data.frame <- function(
     
     obj <- res$obj
     delta_obj_continuous <- res$delta_obj_continuous
+    sample.weights <- res$sample.weights
     # Compare with previous iterations
     delta_obj <- obj - previous$obj
     metropolis <- exp(-1*delta_obj/temp) #+ runif(1)*temp

--- a/R/clhs-internal.R
+++ b/R/clhs-internal.R
@@ -27,6 +27,16 @@
 
   delta_obj_continuous <- rowSums(abs(cont_obj_sampled - eta))
 
+  ## cont_obj_sampled tells use which histogram bucket is most out of whack with
+  ## the target eta for each continuous covariate, adding across rows gets the
+  ## per-bucket today for buckets 1 to n_samples across all covariates
+  
+  ## Compute information about how much each sample contributes to each histogram
+  ## bucket across all features
+  covariate.weights <- lapply(cont_data_strata, function(x) hist(x[[1]], breaks = x[[2]], plot=FALSE)$counts[cut(x[[1]], breaks = x[[2]], labels=FALSE, include.lowest = TRUE)])
+  covariate.weights <- matrix(unlist(covariate.weights), ncol = n_cont_variables, byrow = FALSE)
+  sample.weights <- rowSums(covariate.weights - eta)
+
   # Factor variables
   #
   n_factor_variables <- ncol(data_factor_sampled)
@@ -54,5 +64,5 @@
 
   # Returning results
   #
-  list(obj = obj, delta_obj_continuous = delta_obj_continuous, delta_obj_factor = delta_obj_factor, delta_obj_cor = delta_obj_cor)
+  list(obj = obj, delta_obj_continuous = delta_obj_continuous, delta_obj_factor = delta_obj_factor, delta_obj_cor = delta_obj_cor, sample.weights = sample.weights)
 }


### PR DESCRIPTION
I believe the logic for selecting the worst sample is flawed, not fatally though. If the first bin of the average histogram is the furthest from eta it doesn't makes sense to drop the first sample from the subset. I believe I have a fix and if I can figure out github pull requests I'll make one.