### PR TITLE
Updated clhs.data.frame.R to fix names bug

### DIFF
--- a/R/clhs-data.frame.R
+++ b/R/clhs-data.frame.R
@@ -269,7 +269,7 @@ clhs.data.frame <- function(
   if (progress) close(pb)
   
   if (n_factor > 0) {
-    sampled_data <- data.frame(data_continuous_sampled, data_factor_sampled, stringsAsFactors = TRUE)
+    sampled_data <- data.frame(data_continuous_sampled, data_factor_sampled, stringsAsFactors = TRUE, check.names = FALSE)
     # reordering cols
     sampled_data <- sampled_data[, names(x)]
   } else sampled_data <- data_continuous_sampled


### PR DESCRIPTION
R data frames can handle non-standard parameters now. And GIS layers seem to be full of them. My recent experience with one labelled "DSM_GEOTIFF/1" encountered a problem with this line where the creation of the data.frame on this line changed the name to "DSM_GEOTIFF.1" which causes a problem when we reorder the cols on like 274 as one of the names now doesn't exist.