### PR TITLE
Factors now used to evaluate worst sample

### DIFF
--- a/R/clhs-internal.R
+++ b/R/clhs-internal.R
@@ -39,17 +39,23 @@
 
   # Factor variables
   #
-                              browser()
   n_factor_variables <- ncol(data_factor_sampled)
   if (n_factor_variables > 0) {
     factor_obj_sampled <- lapply(1:n_factor_variables, function(x) table(data_factor_sampled[, x])/nrow(data_factor_sampled))
     delta_obj_factor <- lapply(1:n_factor_variables, function(x) sum(abs(factor_obj_sampled[[x]] - factor_obj[[x]])))
 
     delta_obj_factor <- unlist(delta_obj_factor)#/length(delta_obj_factor) # do we need to ponder w/ the number of factors?
+                               covariate.weights.factors <- lapply(1:n_factor_variables, function(x) abs(factor_obj_sampled[[x]][data_factor_sampled[,x]] - factor_obj[[x]][data_factor_sampled[,x]]))
+    covariate.weights.factors <- matrix(unlist(covariate.weights.factors), ncol = n_factor_variables, byrow = FALSE)
+    sample.weights.factors <- rowSums(covariate.weights.factors)
+    sample.weights.factors <- sample.weights.factors * nrow(data_factor_sampled) ## to put them on scale with continuous
+    
   }
-  else
+  else {
     delta_obj_factor <- 0
-
+    sample.weights.factors <- rep(0, length(sample.weights))
+  }
+  
   # Correlation of continuous data
   #
   cor_sampled <- suppressWarnings(cor(data_continuous_sampled))
@@ -65,5 +71,5 @@
 
   # Returning results
   #
-  list(obj = obj, delta_obj_continuous = delta_obj_continuous, delta_obj_factor = delta_obj_factor, delta_obj_cor = delta_obj_cor, sample.weights = sample.weights)
+  list(obj = obj, delta_obj_continuous = delta_obj_continuous, delta_obj_factor = delta_obj_factor, delta_obj_cor = delta_obj_cor, sample.weights = weights[[1]]*sample.weights + weights[[2]]*sample.weights.factors)
 }

--- a/R/clhs-internal.R
+++ b/R/clhs-internal.R
@@ -39,6 +39,7 @@
 
   # Factor variables
   #
+                              browser()
   n_factor_variables <- ncol(data_factor_sampled)
   if (n_factor_variables > 0) {
     factor_obj_sampled <- lapply(1:n_factor_variables, function(x) table(data_factor_sampled[, x])/nrow(data_factor_sampled))


### PR DESCRIPTION
When dropping the worst sample only continuous covariates were used in evaluating the worst individual. This PR enables factors to contribute to this calculation on an appropriate scale. Net result is closer alignment between proportions of factor levels in sample and populations. 