### PR TITLE
Updates for R CMD check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main, master]
   pull_request:
 
-name: R-CMD-check.yaml
+name: R-CMD-check
 
 permissions: read-all
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,16 +1,13 @@
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -22,72 +19,33 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          extra-packages: any::rcmdcheck
+          needs: check
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          while read -r cmd
-          do
-            eval sudo $cmd
-          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
-          
-      - name: "[Custom block] [macOS] Install spatial libraries"
-        if: runner.os == 'macOS'
-        run: |
-          # conflicts with gfortran from r-lib/actions when linking gcc
-          # rm '/usr/local/bin/gfortran'
-          brew install pkg-config gdal proj geos
-
-      - name: Install dependencies
-        run: |
-          remotes::install_deps(dependencies = TRUE)
-          remotes::install_cran("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_REMOTE_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
     person("Benjamin", "Louis", email = "contact@benjaminlouis-stat.fr", role = "ctb"),
     person("Kiri", "Daust", email = "Kiri.Daust@gov.bc.ca", role = "ctb"),
     person("David", "Clifford", email = "david.clifford@gmail.com", role = "ctb"),
-    person("Andrew", "Brown", email = "andrew.g.brown@usda.gov", role = "ctb"))
+    person("Andrew", "Brown", email = "andrew.g.brown@usda.gov", role = "ctb", comment = c(ORCID="0000-0002-4565-533X")))
 Maintainer: Pierre Roudier <roudierp@landcareresearch.co.nz>
 URL: https://github.com/pierreroudier/clhs/
 BugReports: https://github.com/pierreroudier/clhs/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests: sp,
     rmarkdown,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2
 Collate: 
     'RcppExports.R'
     'clhs-internal.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,15 +1,16 @@
 Package: clhs
 Type: Package
 Title: Conditioned Latin Hypercube Sampling
-Version: 0.9.0
-Date: 2021-10-14
+Version: 0.9.1
+Date: 2025-05-29
 Authors@R: c(
     person("Pierre", "Roudier", email = "roudierp@landcareresearch.co.nz", role = c("aut", "cre")),
     person("Colby", "Brugnard", email = "cbrung@ad.nmsu.edu", role = "ctb"),
     person("Dylan", "Beaudette", email = "dylan.beaudette@ca.usda.gov", role = "ctb"),
     person("Benjamin", "Louis", email = "contact@benjaminlouis-stat.fr", role = "ctb"),
     person("Kiri", "Daust", email = "Kiri.Daust@gov.bc.ca", role = "ctb"),
-    person("David", "Clifford", email = "david.clifford@gmail.com", role = "ctb"))
+    person("David", "Clifford", email = "david.clifford@gmail.com", role = "ctb"),
+    person("Andrew", "Brown", email = "andrew.g.brown@usda.gov", role = "ctb"))
 Maintainer: Pierre Roudier <roudierp@landcareresearch.co.nz>
 URL: https://github.com/pierreroudier/clhs/
 BugReports: https://github.com/pierreroudier/clhs/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Imports: utils,
     methods, 
     grid, 
     ggplot2, 
-    sp,
     sf,
     raster, 
     reshape2, 
@@ -30,7 +29,8 @@ LinkingTo: RcppArmadillo, Rcpp
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyLoad: yes
-Suggests: knitr,
+Suggests: sp,
+    knitr,
     rmarkdown,
     testthat
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 <!-- NEWS.md is maintained by https://cynkra.github.io/fledge, do not edit -->
 
 - Fixed slow example in the plot docs
-- fixed the way RcppAramadillo dependecny is handled so to pass CRAN tests
+- fixed the way RcppArmadillo dependency is handled so to pass CRAN tests
 - added Rcpp and RcppArmadillo dependencies
 - Added C++ implementation (much faster!)
 
@@ -24,37 +24,37 @@
 - Implemented an improved logic to drop worse sample (thanks to David Clifford)
 - Various minor bug fixes to support R > 4.0
 
-# clhs_0.7-2 
+# clhs 0.7-2 
 - Maintenance version fixing new RNG sampler call.
 
-# clhs_0.7-0 
+# clhs 0.7-0 
 - New DLHS method contributed by Benjamin Louis
 - Included possibility to include compulsory/existing samples in the set (thanks to Benjamin Louis)
 - Added more tests
 
-# clhs_0.6-0
+# clhs 0.6-0
 - Added Gower similarity tool (thanks to Colby Brugnard)
 - Switched documentation to Roxygen
 - Implemented the first few tests
 
-# clhs_0.5-7
+# clhs 0.5-7
 - fixed sneaky bug that produced duplicated sampling points (thanks Ankur Gupta for the pointers)
 
-# clhs_0.5-6
+# clhs 0.5-6
 - fixed bug when passing a single raster layer (Github issue #1, thanks Github user GreatEmerald)
 - Raster* clhs method now returns SpatialPointsDataFrame
 
-# clhs_0.5-3
+# clhs 0.5-3
 - corrected dependencies - now depend on R >= 2.14 (due to ggplot2)
 
-# clhs_0.5-2
+# clhs 0.5-2
 - version ready for release when ggplot2_0.9.2.1 is rolled out
 
-# clhs_0.5-1
+# clhs 0.5-1
 - minor bugfix version fixing compatibility issues with ggplot2 >= 0.9.2
 - added ggplot2 in Suggests temporary to fix bug in ggplot2_0.9.2
 
-# clhs_0.5-0 
+# clhs 0.5-0 
 - introduced cost and cost tracking modes
 - general code cleaning
 - improved plot function:
@@ -64,40 +64,40 @@
   - new boxplot mode
 - cleaner NAMESPACE
 
-# clhs_0.4-3
+# clhs 0.4-3
 - Dummy version increment to solve CRAN upload problems
 
-# clhs_0.4-2
+# clhs 0.4-2
 - Added the choice between histogram and density plots in
 the plot method
 
-# clhs_0.4-1 
+# clhs 0.4-1 
 - Improved doc
 - Complete plot.cLHS_result method using ggplot2
 - new reshape2 dependency
 - various buxfixes, esp. for spatial classes
 
-# clhs_0.4-0
+# clhs 0.4-0
 - Introduced cLHS_result S3 class with associated plot method
 - Introduced simple = ... option to the clhs() method. If set to true, returns only the indices of the selected samples, if set to FALSE, returns a cLHS_result object (eg if you want to plot the objective function behaviour).
 - added a plot() method. For the moment, it just plots the objective function.
 
-# clhs_0.3-2
+# clhs 0.3-2
 - slight improvement on the Raster method using rasterToPoints(...)
 - added plotting option for the objective function
 
-# clhs_0.3-1
+# clhs 0.3-1
 - Corrected bug on Raster* methods. Now returns a SpatialPointsDataFrame object.
 
-# clhs_0.3-0
+# clhs 0.3-0
 - Switch to S4 methods
 - Introduced methods for Raster* and SpatialP*DataFrame classes
 
-# clhs_0.2-1
+# clhs 0.2-1
 - changed examples
 
-# clhs_0.2-0
+# clhs 0.2-0
 - Fixed important bugs in the annealing process.
 
-# clhs_0.1-0
+# clhs 0.1-0
 - Initial release of the package.

--- a/R/clhs-data.frame.R
+++ b/R/clhs-data.frame.R
@@ -113,11 +113,11 @@ clhs.data.frame <- function(
     
     if(is.null(include)){
       dat <- data
-      inc <- dat[0,]
+      inc <- dat[0, , drop = FALSE] # keep as matrix if just one column
       ssize <- size
     } else{
       dat <- data[-include,]
-      inc <- data[include,,drop = FALSE] ##keep as matrix if just one row
+      inc <- data[include, , drop = FALSE] # keep as matrix if just one row
       ssize <- size - length(include)
       can.include <- 1:nrow(dat)
     }

--- a/R/clhs-package.R
+++ b/R/clhs-package.R
@@ -45,7 +45,7 @@
 #' @import Rcpp 
 #' @useDynLib clhs
 #' 
-NULL
+"_PACKAGE"
 
 #' Conditioned Latin Hypercube Sampling result
 #' 

--- a/R/clhs-sf.R
+++ b/R/clhs-sf.R
@@ -17,7 +17,7 @@ clhs.sf <- function(
     # When coords are used only points/multipoints are supported
     if (! st_geometry_type(x, by_geometry = FALSE) %in% c("POINT", "MULTIPOINT")) {
       stop(
-        "When use.coords` is set to TRUE, only POINT/MULTIPOINT geometries are supported.",
+        "When `use.coords` is set to TRUE, only POINT/MULTIPOINT geometries are supported.",
         call. = FALSE
       )
     }

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -30,7 +30,7 @@
 #' 
 #' data(meuse.grid)
 #' coordinates(meuse.grid) = ~x+y
-#' proj4string(meuse.grid) <- CRS("+init=epsg:28992")
+#' proj4string(meuse.grid) <- CRS("EPSG:28992")
 #' gridded(meuse.grid) = TRUE
 #' ms <- stack(meuse.grid)
 #' 

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -24,7 +24,7 @@
 #' 
 #' @export
 #' 
-#' @examples 
+#' @examplesIf requireNamespace("sp") 
 #' library(raster)
 #' library(sp)
 #' 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![R build status](https://github.com/pierreroudier/clhs/workflows/R-CMD-check/badge.svg)](https://github.com/pierreroudier/clhs/actions)
+[![R-CMD-check](https://github.com/pierreroudier/clhs/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/pierreroudier/clhs/actions/workflows/R-CMD-check.yaml)
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/clhs)](https://cran.r-project.org/package=clhs)
 [![Total_Downloads](http://cranlogs.r-pkg.org/badges/grand-total/clhs)](https://cran.r-project.org/package=clhs)
 

--- a/man/similarity_buffer.Rd
+++ b/man/similarity_buffer.Rd
@@ -36,6 +36,7 @@ a RasterStack
 Calculates Gower's similarity index for every pixel within an given radius buffer of each sampling point
 }
 \examples{
+\dontshow{if (requireNamespace("sp") ) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(raster)
 library(sp)
 
@@ -50,7 +51,7 @@ set.seed(1)
 pts <- clhs(ms, size = 3, iter = 100, progress = FALSE, simple = FALSE)
 gw <- similarity_buffer(ms, pts$sampled_data, buffer = 500)
 plot(gw)
-
+\dontshow{\}) # examplesIf}
 }
 \references{
 Brungard, C. and Johanson, J. 2015. The gate's locked! I can't get to the exact 

--- a/man/similarity_buffer.Rd
+++ b/man/similarity_buffer.Rd
@@ -41,7 +41,7 @@ library(sp)
 
 data(meuse.grid)
 coordinates(meuse.grid) = ~x+y
-proj4string(meuse.grid) <- CRS("+init=epsg:28992")
+proj4string(meuse.grid) <- CRS("EPSG:28992")
 gridded(meuse.grid) = TRUE
 ms <- stack(meuse.grid)
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -8,7 +8,7 @@
 ##
 ## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
 ## support within Armadillo prefers / requires it
-CXX_STD = CXX11
+# CXX_STD = CXX11
 
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -8,7 +8,7 @@
 ##
 ## And with R 3.4.0, and RcppArmadillo 0.7.960.*, we turn C++11 on as OpenMP
 ## support within Armadillo prefers / requires it
-CXX_STD = CXX11
+# CXX_STD = CXX11
 
 PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) 
 PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/tests/testthat/test-clhs-gower.R
+++ b/tests/testthat/test-clhs-gower.R
@@ -1,7 +1,9 @@
 context("clhs-gower")
 
 test_that("Gower similarity works", {
-  
+ 
+  skip_if_not_installed("sp")
+   
   library(raster)
   library(sp)
 

--- a/tests/testthat/test-spdf.R
+++ b/tests/testthat/test-spdf.R
@@ -2,6 +2,8 @@ context("clhs-sp")
 
 test_that("clhs on a SpatialPointsDataFrame works", {
   
+  skip_if_not_installed("sp")
+  
   suppressWarnings(RNGversion("3.5.0"))
   set.seed(1)
   

--- a/tests/testthat/test-spdf.R
+++ b/tests/testthat/test-spdf.R
@@ -16,7 +16,7 @@ test_that("clhs on a SpatialPointsDataFrame works", {
   spdf <- sp::SpatialPointsDataFrame(
     coords = df[, c("x", "y")],
     data = df[, c("a", "b", "c")],
-    proj4string = sp::CRS("+init=epsg:4326")
+    proj4string = sp::CRS("EPSG:4326")
   )
   
   res1 <- clhs(spdf, size = 5, iter = 100, progress = FALSE, simple = TRUE)


### PR DESCRIPTION
Hey @pierreroudier!

I wanted to propose some minor updates to {clhs}, so ran it through R CMD check and made some preliminary minor fixes. 

 - Dropped C++11 specification as it is not essential
 - Made some minor updates to NEWS.md to fix version number parsing (generates check NOTE)
 - Moved sp package to suggests--afaict it is only used in tests and examples, and the slots are accessed directly in the SpatialPointsDataFrame method so does not explicitly rely on importing anything (having it in imports generates check NOTE)
 - Updated Roxygen incantations for package documentation
 - Fixed some typos
 - Fixed error "Not a matrix" with `use.cpp=TRUE` and single column input (a degenerate case I ran into while mocking up a simple example for testing
 - Replace PROJ4-style `"+init=epsg:XXXX"` strings with `"EPSG:XXXX"`
 - Updated R-CMD-check.yaml github workflow to use the latest from {usethis}, and updated badge in README.md

I will be proposing a couple more PRs based on these updates.

Thanks for your consideration, hope you are doing well!!